### PR TITLE
Switch from double to single quotes

### DIFF
--- a/tests/manage.py
+++ b/tests/manage.py
@@ -2,8 +2,8 @@
 import os
 import sys
 
-if __name__ == "__main__":
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
+if __name__ == '__main__':
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'settings')
 
     from django.core.management import execute_from_command_line
 


### PR DESCRIPTION
Following ericwxyang's choice to use single quotes, replace double quotes in the tests directory with single quotes.